### PR TITLE
fix: update site-text v1.schema

### DIFF
--- a/api/src/core/sql/schema/v1.schema.sql
+++ b/api/src/core/sql/schema/v1.schema.sql
@@ -532,32 +532,32 @@ create table word_range_tags_votes(
 
 -- SITE TEXT -------------------------------------------------------------
 
-create table site_text_words (
+create table site_text_word_definitions (
   site_text_id bigserial primary key,
-  word_id bigint not null references words(word_id),
+  word_definition_id bigint not null references word_definitions(word_definition_id),
   created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   created_by bigint not null references users(user_id),
-  unique (word_id)
+  unique (word_definition_id)
 );
 
-create table site_text_phrases (
+create table site_text_phrase_definitions (
   site_text_id bigserial primary key,
-  phrase_id bigint not null references phrases(phrase_id),
+  phrase_definition_id bigint not null references phrase_definitions(phrase_definition_id),
   created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   created_by bigint not null references users(user_id),
-  unique (phrase_id)
+  unique (phrase_definition_id)
 );
 
 create table site_text_translation_votes(
   site_text_vote_id bigserial primary key,
   user_id bigint not null references users(user_id),
-  from_id bigint not null,
-  to_id bigint not null,
+  from_definition_id bigint not null,
+  to_definition_id bigint not null,
   from_type_is_word bool not null, -- true = word, false = phrase
   to_type_is_word bool not null, -- true = word, false = phrase
   vote bool,
   last_updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  unique (user_id, from_id, to_id, from_type_is_word, to_type_is_word)
+  unique (user_id, from_definition_id, to_definition_id, from_type_is_word, to_type_is_word)
 );
 
 -- MAPS -------------------------------------------------------------


### PR DESCRIPTION
This is small PR contains updated table schemas for site-text feature.

at `data-load.service.ts`, we have to create a `site-text-word-defintions`, or `site-text-phrase-definitions` with simple definition "Site User Interface Text".

for example, let's create a site text "crowd.rocks".

1. create a `word` with `wordlikeString` "crowd.rocks"
2. create a `word_definition` with `word_id`, and "Site User Interface Text" definition.
3. create a `site-text-word-definition` with `word_definition_id`.


