### PR TITLE
Add Chat Icon

### DIFF
--- a/frontend/src/components/common/Card/Card.tsx
+++ b/frontend/src/components/common/Card/Card.tsx
@@ -4,9 +4,11 @@ import {
   CustomCardTitle,
   CustomCardContent,
   CustomCardHeader,
+  CustomChatIcon,
 } from './styled';
 
 import { VoteButtonsHerizontal } from '../VoteButtonsHerizontal';
+import { chatbubbleEllipsesSharp } from 'ionicons/icons';
 
 type CardProps = {
   content?: string;
@@ -17,6 +19,9 @@ type CardProps = {
     downVotes: number;
     onVoteUpClick: () => void;
     onVoteDownClick: () => void;
+  };
+  discussion?: {
+    onChatClick: () => void;
   };
   onClick?: () => void;
   routerLink?: string;
@@ -29,8 +34,12 @@ export function Card({
   onClick,
   routerLink,
   vote,
+  discussion,
 }: CardProps) {
   const voteButtonCom = vote ? <VoteButtonsHerizontal {...vote} /> : null;
+  const chatButton = discussion ? (
+    <CustomChatIcon icon={chatbubbleEllipsesSharp} />
+  ) : null;
 
   return (
     <CustomCard onClick={() => onClick && onClick()} routerLink={routerLink}>
@@ -44,6 +53,7 @@ export function Card({
       <CustomCardContent>
         {description}
         {voteFor === 'description' ? voteButtonCom : null}
+        {chatButton}
       </CustomCardContent>
     </CustomCard>
   );

--- a/frontend/src/components/common/Card/styled.ts
+++ b/frontend/src/components/common/Card/styled.ts
@@ -3,6 +3,7 @@ import {
   IonCardContent,
   IonCardHeader,
   IonCardTitle,
+  IonIcon,
 } from '@ionic/react';
 import { styled } from 'styled-components';
 
@@ -21,6 +22,13 @@ export const CustomCardTitle = styled(IonCardTitle)(() => ({
 export const CustomCardContent = styled(IonCardContent)(() => ({}));
 
 export const CustomCardHeader = styled(IonCardHeader)(() => ({}));
+
+// TODO: would be nice to get this to float to the right of the container...
+export const CustomChatIcon = styled(IonIcon)(() => ({
+  cursor: 'pointer',
+  fontSize: '20px',
+  padding: '5px',
+}));
 
 export const Layout = styled.div`
   display: flex;


### PR DESCRIPTION
First step towards https://github.com/etenlab/crowd.rocks/issues/22
- optional chat Icon with `onChatClick` on CardComponents. 
- Use with card components, defining `onChatClick()` for routing to and displaying the discussion for item.
- Todo: needs a little help with styling it to correct position on card.
