### PR TITLE
Fix header in dark theme mode

### DIFF
--- a/frontend/src/Body.css
+++ b/frontend/src/Body.css
@@ -25,6 +25,11 @@
   --ion-background-color: var(--ca-menu-background-color);
 }
 
+.dark {
+  color: var(--ca-menu-header-text);
+  background-color: var(--ca-menu-background-color);
+}
+
 .theme-icon {
   margin: 0px 7px;
 }


### PR DESCRIPTION
Fixed header text to have same color are light-themed text in OS light and dark modes. I figured we can just keep that tan color because it doesn't  have a high contrast. 