### PR TITLE
Fix/maps types error handling

### DIFF
--- a/api/src/components/documents/documents.service.ts
+++ b/api/src/components/documents/documents.service.ts
@@ -24,16 +24,13 @@ export class DocumentsService {
     const dbPoolClient = await this.pg.pool.connect();
 
     try {
-      dbPoolClient.query('BEGIN');
       const document_id = await this.documentsRepository.saveDocumentTrn(
         document,
         token,
         dbPoolClient,
       );
-      await dbPoolClient.query('COMMIT');
       return document_id;
     } catch (error) {
-      dbPoolClient.query('ROLLBACK');
       throw error;
     } finally {
       dbPoolClient.release();

--- a/api/src/components/maps/maps.service.ts
+++ b/api/src/components/maps/maps.service.ts
@@ -89,7 +89,6 @@ export class MapsService {
     const dbPoolClient = await this.pg.pool.connect();
     try {
       //-- Save map
-      dbPoolClient.query('BEGIN');
       const { map_id } = await this.mapsRepository.saveOriginalMapTrn({
         mapFileName,
         content_file_id,
@@ -100,18 +99,13 @@ export class MapsService {
         dialect_code: dialect_code || undefined,
         geo_code: geo_code || undefined,
       });
-      await dbPoolClient.query('COMMIT');
-      // parsing depends on results of saveOriginalMapTrn so we must commit and start a new transaction
-      dbPoolClient.query('BEGIN');
       const res = await this.parseOrigMapTrn({
         map_id,
         dbPoolClient,
         token,
       });
-      dbPoolClient.query('COMMIT');
       return res;
     } catch (error) {
-      dbPoolClient.query('ROLLBACK');
       throw error;
     } finally {
       dbPoolClient.release();

--- a/api/src/components/maps/maps.service.ts
+++ b/api/src/components/maps/maps.service.ts
@@ -2,13 +2,11 @@ import { Injectable, Inject, forwardRef, Logger } from '@nestjs/common';
 
 import {
   MapFileListConnection,
-  GetOrigMapContentOutput,
   GetOrigMapPhrasesInput,
   GetOrigMapPhrasesOutput,
   GetOrigMapsListOutput,
   GetOrigMapWordsInput,
   GetOrigMapWordsOutput,
-  GetTranslatedMapContentOutput,
   MapFileOutput,
   MapPhraseTranslations,
   MapWordTranslations,
@@ -19,7 +17,7 @@ import { parseSync as readSvg, stringify } from 'svgson';
 import { WordsService } from '../words/words.service';
 import { MapsRepository } from './maps.repository';
 import { WordUpsertInput } from '../words/types';
-import { LanguageInfo } from '../../common/types';
+import { ErrorType, LanguageInfo } from '../../common/types';
 import { DEFAULT_NEW_MAP_LANGUAGE } from '../../common/const';
 import { PostgresService } from '../../core/postgres.service';
 import { WordDefinitionsService } from '../definitions/word-definitions.service';
@@ -125,8 +123,18 @@ export class MapsService {
     dbPoolClient,
     token,
   }: IParseOrigMapParams): Promise<MapFileOutput> {
-    const { language, content_file_id, map_file_name, created_at, created_by } =
-      await this.mapsRepository.getOrigMapWithContentUrl(map_id);
+    const origMapInfo = await this.mapsRepository.getOrigMapWithContentUrl(
+      map_id,
+    );
+    if (origMapInfo.error !== ErrorType.NoError || !origMapInfo.mapFileInfo) {
+      return {
+        error: origMapInfo.error,
+        mapFileInfo: null,
+      };
+    }
+    const {
+      mapFileInfo: { language, content_file_id },
+    } = origMapInfo;
     const { language_code, dialect_code, geo_code } = language;
     const origMapString = await this.fileService.getFileContentAsString(
       content_file_id,
@@ -166,21 +174,8 @@ export class MapsService {
     await dbPoolClient.query('COMMIT');
 
     return {
-      map_file_name,
-      map_file_name_with_langs: putLangCodesToFileName(map_file_name, {
-        language_code,
-        dialect_code,
-        geo_code,
-      }),
-      original_map_id: map_id,
-      created_at,
-      created_by,
-      is_original: true,
-      language: {
-        language_code,
-        dialect_code,
-        geo_code,
-      },
+      error: ErrorType.NoError,
+      mapFileInfo: origMapInfo.mapFileInfo,
     };
   }
 
@@ -289,8 +284,8 @@ export class MapsService {
       });
       const allMapsList = [...origMaps.mapList, ...translatedMaps.mapList].sort(
         (map1, map2) =>
-          map1.map_file_name_with_langs.localeCompare(
-            map2.map_file_name_with_langs,
+          map1.mapFileInfo!.map_file_name_with_langs.localeCompare(
+            map2.mapFileInfo!.map_file_name_with_langs,
           ),
       );
 
@@ -308,10 +303,10 @@ export class MapsService {
       for (let i = 0; i < allMapsList.length; i++) {
         const tempMap = allMapsList[i];
         const tempCursor = makeCursorStr(
-          tempMap.is_original
-            ? tempMap.original_map_id
-            : tempMap.translated_map_id!,
-          tempMap.is_original,
+          tempMap.mapFileInfo?.is_original
+            ? tempMap.mapFileInfo!.original_map_id
+            : tempMap.mapFileInfo!.translated_map_id!,
+          tempMap.mapFileInfo!.is_original,
         );
 
         if (after === null && offset === null) {
@@ -369,13 +364,11 @@ export class MapsService {
     };
   }
 
-  async getOrigMapContent(id: string): Promise<GetOrigMapContentOutput> {
+  async getOrigMapContent(id: string): Promise<MapFileOutput> {
     return this.mapsRepository.getOrigMapWithContentUrl(id);
   }
 
-  async getTranslatedMapContent(
-    id: string,
-  ): Promise<GetTranslatedMapContentOutput> {
+  async getTranslatedMapContent(id: string): Promise<MapFileOutput> {
     const mapFileInfo =
       await this.mapsRepository.getTranslatedMapWithContentUrl(id);
     return mapFileInfo;
@@ -591,18 +584,32 @@ export class MapsService {
   }
 
   async translateMapAndSaveTranslatedTrn(
-    origMapId,
-    token,
+    origMapId: string | null | undefined,
+    token: string,
     dbPoolClient: PoolClient,
     toLang?: LanguageInput,
   ): Promise<Array<string>> {
+    if (!origMapId) {
+      Logger.error(
+        `mapsService#translateMapAndSaveTranslatedTrn: origMapId not provided.`,
+      );
+      return [];
+    }
     const p0 = performance.now();
     Logger.log(
       `START translating of orig map id ${origMapId} to lang ${toLang?.language_code}`,
     );
     const translatedMapIds: Array<string> = [];
-    const { content_file_id, map_file_name } =
-      await this.mapsRepository.getOrigMapWithContentUrl(origMapId);
+    const origMap = await this.mapsRepository.getOrigMapWithContentUrl(
+      origMapId,
+    );
+    if (!origMap.mapFileInfo) {
+      Logger.error(
+        `mapsService#translateMapAndSaveTranslatedTrn: origMap witn id ${origMapId} not found.`,
+      );
+      return [];
+    }
+    const { content_file_id, map_file_name } = origMap.mapFileInfo;
 
     const { origMapWords } = await this.getOrigMapWords({
       original_map_id: origMapId,
@@ -769,13 +776,17 @@ export class MapsService {
     });
 
     for (const translatedMap of translatedMaps.mapList) {
-      translatedMap.translated_map_id &&
-        (await this.deleteTranslatedMap(translatedMap.translated_map_id));
+      translatedMap.mapFileInfo?.translated_map_id &&
+        (await this.deleteTranslatedMap(
+          translatedMap.mapFileInfo.translated_map_id,
+        ));
     }
 
     const deletedMapId = await this.mapsRepository.deleteOriginalMap(mapId);
-    await this.fileService.deleteFile(mapInfo.preview_file_id!);
-    await this.fileService.deleteFile(mapInfo.content_file_id!);
+    mapInfo.mapFileInfo?.preview_file_id &&
+      (await this.fileService.deleteFile(mapInfo.mapFileInfo.preview_file_id));
+    mapInfo.mapFileInfo?.content_file_id &&
+      (await this.fileService.deleteFile(mapInfo.mapFileInfo.content_file_id));
     return deletedMapId;
   }
 
@@ -784,35 +795,37 @@ export class MapsService {
       mapId,
     );
     const deletedMapId = await this.mapsRepository.deleteTranslatedMap(mapId);
-    await this.fileService.deleteFile(mapInfo.content_file_id!);
+    mapInfo.mapFileInfo?.content_file_id &&
+      (await this.fileService.deleteFile(mapInfo.mapFileInfo.content_file_id));
     return deletedMapId;
   }
 
   async translationsReset(token): Promise<void> {
     const dbPoolClient = await this.pg.pool.connect();
     try {
-      dbPoolClient.query('BEGIN');
       await this.mapsRepository.deleteAllOriginalMapWordsTrn(dbPoolClient);
       await this.mapsRepository.deleteAllOriginalMapPhrasesTrn(dbPoolClient);
       await this.mapsRepository.deleteAllTranslatedMapsTrn(dbPoolClient);
-      await dbPoolClient.query('COMMIT');
       const allOriginalMaps = await this.mapsRepository.getOrigMaps();
       for (const origMap of allOriginalMaps.mapList) {
-        dbPoolClient.query('BEGIN');
+        if (!origMap.mapFileInfo?.original_map_id) {
+          Logger.error(
+            `mapsService#translationsReset: origMap.mapFileInfo?.original_map_id is falsy`,
+          );
+          continue;
+        }
         await this.parseOrigMapTrn({
-          map_id: origMap.original_map_id,
+          map_id: origMap.mapFileInfo.original_map_id,
           token,
           dbPoolClient,
         });
         await this.translateMapAndSaveTranslatedTrn(
-          origMap.original_map_id,
+          origMap.mapFileInfo.original_map_id,
           token,
           dbPoolClient,
         );
-        await dbPoolClient.query('COMMIT');
       }
     } catch (error) {
-      await dbPoolClient.query('ROLLBACK');
       throw error;
     } finally {
       dbPoolClient.release();
@@ -828,7 +841,9 @@ export class MapsService {
     };
     const originalMaps = await this.mapsRepository.getOrigMaps();
     if (!(originalMaps.mapList?.length > 0)) return;
-    const origMapIds = originalMaps.mapList.map((m) => m.original_map_id);
+    const origMapIds = originalMaps.mapList.map(
+      (m) => m.mapFileInfo?.original_map_id,
+    );
     const dbPoolClient = await this.pg.pool.connect();
     try {
       for (const origMapId of origMapIds) {

--- a/api/src/components/maps/types.ts
+++ b/api/src/components/maps/types.ts
@@ -12,7 +12,7 @@ import { Phrase } from '../phrases/types';
 import { Word } from '../words/types';
 
 @ObjectType()
-export class MapFileOutput {
+export class MapFileInfo {
   @Field(() => Boolean) is_original: boolean;
   @Field(() => ID) original_map_id: string;
   @Field(() => String, { nullable: true }) translated_percent?: string;
@@ -24,8 +24,13 @@ export class MapFileOutput {
   @Field(() => ID, { nullable: true }) translated_map_id?: string;
   @Field(() => ID, { nullable: true }) preview_file_url?: string;
   @Field(() => ID, { nullable: true }) preview_file_id?: string;
-  @Field(() => ID, { nullable: true }) content_file_url?: string;
-  @Field(() => ID, { nullable: true }) content_file_id?: string;
+  @Field(() => ID) content_file_url: string;
+  @Field(() => ID) content_file_id: string;
+}
+@ObjectType()
+export class MapFileOutput extends GenericOutput {
+  @Field(() => MapFileInfo, { nullable: true })
+  mapFileInfo?: MapFileInfo | null;
 }
 @InputType()
 export class GetOrigMapListInput {
@@ -74,18 +79,18 @@ export class MapFileListConnection {
 export class GetOrigMapContentInput {
   @Field(() => ID) original_map_id: string;
 }
-@ObjectType()
-export class GetOrigMapContentOutput extends MapFileOutput {
-  @Field(() => String) content_file_url: string;
-  @Field(() => String) content_file_id: string;
-}
+// @ObjectType()
+// export class GetOrigMapContentOutput extends MapFileOutput {
+//   @Field(() => String) content_file_url: string;
+//   @Field(() => String) content_file_id: string;
+// }
 
 @InputType()
 export class GetTranslatedMapContentInput {
   @Field(() => ID) translated_map_id: string;
 }
-@ObjectType()
-export class GetTranslatedMapContentOutput extends GetOrigMapContentOutput {}
+// @ObjectType()
+// export class GetTranslatedMapContentOutput extends GetOrigMapContentOutput {}
 
 @InputType()
 export class GetOrigMapWordsInput {

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -292,22 +292,6 @@ input GetOrigMapContentInput {
   original_map_id: ID!
 }
 
-type GetOrigMapContentOutput {
-  content_file_id: String!
-  content_file_url: String!
-  created_at: String!
-  created_by: ID!
-  is_original: Boolean!
-  language: LanguageOutput!
-  map_file_name: String!
-  map_file_name_with_langs: String!
-  original_map_id: ID!
-  preview_file_id: ID
-  preview_file_url: ID
-  translated_map_id: ID
-  translated_percent: String
-}
-
 input GetOrigMapListInput {
   search: String
 }
@@ -346,22 +330,6 @@ type GetOrigMapsListOutput {
 
 input GetTranslatedMapContentInput {
   translated_map_id: ID!
-}
-
-type GetTranslatedMapContentOutput {
-  content_file_id: String!
-  content_file_url: String!
-  created_at: String!
-  created_by: ID!
-  is_original: Boolean!
-  language: LanguageOutput!
-  map_file_name: String!
-  map_file_name_with_langs: String!
-  original_map_id: ID!
-  preview_file_id: ID
-  preview_file_url: ID
-  translated_map_id: ID
-  translated_percent: String
 }
 
 type IFile {
@@ -437,14 +405,9 @@ type MapDeleteOutput {
   error: ErrorType!
 }
 
-type MapFileListConnection {
-  edges: [MapFileOutputEdge!]!
-  pageInfo: PageInfo!
-}
-
-type MapFileOutput {
-  content_file_id: ID
-  content_file_url: ID
+type MapFileInfo {
+  content_file_id: ID!
+  content_file_url: ID!
   created_at: String!
   created_by: ID!
   is_original: Boolean!
@@ -456,6 +419,16 @@ type MapFileOutput {
   preview_file_url: ID
   translated_map_id: ID
   translated_percent: String
+}
+
+type MapFileListConnection {
+  edges: [MapFileOutputEdge!]!
+  pageInfo: PageInfo!
+}
+
+type MapFileOutput {
+  error: ErrorType!
+  mapFileInfo: MapFileInfo
 }
 
 type MapFileOutputEdge {
@@ -895,7 +868,7 @@ type Query {
   getAllTranslationFromSiteTextDefinitionID(dialect_code: String, geo_code: String, language_code: String!, site_text_id: ID!, site_text_type_is_word: Boolean!): SiteTextTranslationWithVoteListOutput!
   getDocument(input: GetDocumentInput!): GetDocumentOutput!
   getFlagsFromRef(parent_id: String!, parent_table: TableNameType!): FlagsOutput!
-  getOrigMapContent(input: GetOrigMapContentInput!): GetOrigMapContentOutput!
+  getOrigMapContent(input: GetOrigMapContentInput!): MapFileOutput!
   getOrigMapPhrases(input: GetOrigMapPhrasesInput): GetOrigMapPhrasesOutput!
   getOrigMapWords(input: GetOrigMapWordsInput): GetOrigMapWordsOutput!
   getOrigMapsList(input: GetOrigMapListInput!): GetOrigMapsListOutput!
@@ -913,7 +886,7 @@ type Query {
   getRecommendedTranslationFromDefinitionID(from_definition_id: ID!, from_type_is_word: Boolean!, langInfo: LanguageInput!): TranslationWithVoteOutput!
   getRecommendedTranslationFromSiteTextDefinitionID(dialect_code: String, geo_code: String, language_code: String!, site_text_id: ID!, site_text_type_is_word: Boolean!): SiteTextTranslationWithVoteOutput!
   getSiteTextTranslationVoteStatus(from_type_is_word: Boolean!, to_type_is_word: Boolean!, translation_id: ID!): SiteTextTranslationVoteStatusOutputRow!
-  getTranslatedMapContent(input: GetTranslatedMapContentInput!): GetTranslatedMapContentOutput!
+  getTranslatedMapContent(input: GetTranslatedMapContentInput!): MapFileOutput!
   getTranslationsByFromDefinitionId(definition_id: ID!, from_definition_type_is_word: Boolean!, langInfo: LanguageInput!): TranslationWithVoteListOutput!
   getWordDefinitionVoteStatus(word_definition_id: ID!): DefinitionVoteStatusOutputRow!
   getWordDefinitionsByFlag(after: ID, first: Int, flag_name: FlagType!): WordDefinitionListConnection!

--- a/frontend/graphql.schema.json
+++ b/frontend/graphql.schema.json
@@ -2210,209 +2210,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "GetOrigMapContentOutput",
-        "description": null,
-        "fields": [
-          {
-            "name": "content_file_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "content_file_url",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_by",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "is_original",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "language",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "LanguageOutput",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "map_file_name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "map_file_name_with_langs",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "original_map_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "preview_file_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "preview_file_url",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "translated_map_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "translated_percent",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "INPUT_OBJECT",
         "name": "GetOrigMapListInput",
         "description": null,
@@ -2754,209 +2551,6 @@
           }
         ],
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "GetTranslatedMapContentOutput",
-        "description": null,
-        "fields": [
-          {
-            "name": "content_file_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "content_file_url",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_by",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "is_original",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "language",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "LanguageOutput",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "map_file_name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "map_file_name_with_langs",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "original_map_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "preview_file_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "preview_file_url",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "translated_map_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "translated_percent",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -3604,58 +3198,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "MapFileListConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "MapFileOutputEdge",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MapFileOutput",
+        "name": "MapFileInfo",
         "description": null,
         "fields": [
           {
@@ -3663,9 +3206,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3675,9 +3222,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3837,6 +3388,96 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MapFileListConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MapFileOutputEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MapFileOutput",
+        "description": null,
+        "fields": [
+          {
+            "name": "error",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ErrorType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mapFileInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "MapFileInfo",
               "ofType": null
             },
             "isDeprecated": false,
@@ -10440,7 +10081,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "GetOrigMapContentOutput",
+                "name": "MapFileOutput",
                 "ofType": null
               }
             },
@@ -11226,7 +10867,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "GetTranslatedMapContentOutput",
+                "name": "MapFileOutput",
                 "ofType": null
               }
             },

--- a/frontend/src/components/map/MapList/MapItem.tsx
+++ b/frontend/src/components/map/MapList/MapItem.tsx
@@ -4,7 +4,7 @@ import { downloadOutline, trashBin } from 'ionicons/icons';
 import { styled } from 'styled-components';
 
 import {
-  MapFileOutput,
+  MapFileInfo,
   useGetOrigMapContentLazyQuery,
   useGetTranslatedMapContentLazyQuery,
 } from '../../../generated/graphql';
@@ -14,8 +14,8 @@ import { downloadFromUrl } from '../../../common/utility';
 import { useAppContext } from '../../../hooks/useAppContext';
 
 export type TMapItemProps = React.HTMLAttributes<HTMLIonItemElement> & {
-  mapItem: MapFileOutput;
-  candidateForDeletionRef: React.MutableRefObject<MapFileOutput | undefined>;
+  mapItem: MapFileInfo;
+  candidateForDeletionRef: React.MutableRefObject<MapFileInfo | undefined>;
   setIsMapDeleteModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   showDelete: boolean;
 };
@@ -78,11 +78,12 @@ const NotStyledMapItem = ({
     origMapContent.data &&
     !origMapContent.error &&
     !origMapContent.loading &&
-    downloadFlagRef.current === 'original'
+    downloadFlagRef.current === 'original' &&
+    origMapContent.data.getOrigMapContent.mapFileInfo
   ) {
     downloadFromUrl(
-      origMapContent.data.getOrigMapContent.map_file_name,
-      origMapContent.data.getOrigMapContent.content_file_url,
+      origMapContent.data.getOrigMapContent.mapFileInfo.map_file_name,
+      origMapContent.data.getOrigMapContent.mapFileInfo.content_file_url,
     );
     downloadFlagRef.current = null;
   }
@@ -91,12 +92,14 @@ const NotStyledMapItem = ({
     translatedMapContent.data &&
     !translatedMapContent.error &&
     !translatedMapContent.loading &&
-    downloadFlagRef.current === 'translated'
+    downloadFlagRef.current === 'translated' &&
+    translatedMapContent.data.getTranslatedMapContent.mapFileInfo
   ) {
     downloadFromUrl(
-      translatedMapContent.data.getTranslatedMapContent
+      translatedMapContent.data.getTranslatedMapContent.mapFileInfo
         .map_file_name_with_langs,
-      translatedMapContent.data.getTranslatedMapContent.content_file_url,
+      translatedMapContent.data.getTranslatedMapContent.mapFileInfo
+        .content_file_url,
     );
     downloadFlagRef.current = null;
   }

--- a/frontend/src/components/map/MapList/MapsList.tsx
+++ b/frontend/src/components/map/MapList/MapsList.tsx
@@ -22,7 +22,7 @@ import { Caption } from '../../common/Caption/Caption';
 import { MapTools } from './MapsTools';
 import {
   ErrorType,
-  MapFileOutput,
+  MapFileInfo,
   useGetAllMapsListLazyQuery,
   useIsAdminLoggedInLazyQuery,
   useMapDeleteMutation,
@@ -77,7 +77,7 @@ export const MapList: React.FC = () => {
   const { makeMapThumbnail } = useMapTranslationTools();
   const [isMapDeleteModalOpen, setIsMapDeleteModalOpen] = useState(false);
   const [isMapResetModalOpen, setIsMapResetModalOpen] = useState(false);
-  const candidateForDeletion = useRef<MapFileOutput | undefined>();
+  const candidateForDeletion = useRef<MapFileInfo | undefined>();
 
   useEffect(() => {
     if (loadingSendMapFile || loadingUploadFile || loadingMapDelete) return;
@@ -300,19 +300,23 @@ export const MapList: React.FC = () => {
       allMapsQuery?.getAllMapsList.edges?.length ? (
         allMapsQuery?.getAllMapsList.edges
           ?.filter((edge) => {
-            return edge.node.map_file_name_with_langs
+            return (edge.node.mapFileInfo?.map_file_name_with_langs || '')
               .toLowerCase()
               .includes(filter.toLowerCase());
           })
-          .map((edge) => (
-            <MapItem
-              mapItem={edge.node}
-              key={edge.cursor}
-              candidateForDeletionRef={candidateForDeletion}
-              setIsMapDeleteModalOpen={setIsMapDeleteModalOpen}
-              showDelete={!!isAdminRes?.loggedInIsAdmin.isAdmin}
-            />
-          ))
+          .map((edge) =>
+            edge.node.mapFileInfo ? (
+              <MapItem
+                mapItem={edge.node.mapFileInfo}
+                key={edge.cursor}
+                candidateForDeletionRef={candidateForDeletion}
+                setIsMapDeleteModalOpen={setIsMapDeleteModalOpen}
+                showDelete={!!isAdminRes?.loggedInIsAdmin.isAdmin}
+              />
+            ) : (
+              <>{edge.node.error}</>
+            ),
+          )
       ) : (
         <div> {tr('No maps found')} </div>
       ),

--- a/frontend/src/components/map/gql.graphql
+++ b/frontend/src/components/map/gql.graphql
@@ -25,20 +25,25 @@ fragment WordWithVotesFragment on MapWordWithVotes {
 }
 
 fragment MapFileOutputFragment on MapFileOutput {
-  is_original
-  original_map_id
-  translated_map_id
-  map_file_name
-  translated_percent
-  language {
-    language_code
-    dialect_code
-    geo_code
+  error
+  mapFileInfo {
+    is_original
+    original_map_id
+    translated_map_id
+    map_file_name
+    translated_percent
+    language {
+      language_code
+      dialect_code
+      geo_code
+    }
+    created_at
+    created_by
+    map_file_name_with_langs
+    preview_file_url
+    content_file_url
+    content_file_id
   }
-  created_at
-  created_by
-  map_file_name_with_langs
-  preview_file_url
 }
 
 fragment MapFileOutputEdgeFragment on MapFileOutputEdge {
@@ -125,18 +130,7 @@ query GetAllMapsList($lang: LanguageInput, $after: ID, $first: Int) {
 
 query GetTranslatedMapContent($id: ID!) {
   getTranslatedMapContent(input: { translated_map_id: $id }) {
-    translated_map_id
-    map_file_name
-    translated_percent
-    language {
-      language_code
-      dialect_code
-      geo_code
-    }
-    created_at
-    created_by
-    content_file_url
-    map_file_name_with_langs
+    ...MapFileOutputFragment
   }
 }
 
@@ -148,12 +142,7 @@ query IsAdminLoggedIn($input: IsAdminIdInput!) {
 
 query GetOrigMapContent($id: ID!) {
   getOrigMapContent(input: { original_map_id: $id }) {
-    original_map_id
-    map_file_name_with_langs
-    map_file_name
-    created_at
-    created_by
-    content_file_url
+    ...MapFileOutputFragment
   }
 }
 
@@ -171,8 +160,7 @@ mutation MapUpload(
   ) {
     error
     mapFileOutput {
-      original_map_id
-      map_file_name
+      ...MapFileOutputFragment
     }
   }
 }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -328,23 +328,6 @@ export type GetOrigMapContentInput = {
   original_map_id: Scalars['ID']['input'];
 };
 
-export type GetOrigMapContentOutput = {
-  __typename?: 'GetOrigMapContentOutput';
-  content_file_id: Scalars['String']['output'];
-  content_file_url: Scalars['String']['output'];
-  created_at: Scalars['String']['output'];
-  created_by: Scalars['ID']['output'];
-  is_original: Scalars['Boolean']['output'];
-  language: LanguageOutput;
-  map_file_name: Scalars['String']['output'];
-  map_file_name_with_langs: Scalars['String']['output'];
-  original_map_id: Scalars['ID']['output'];
-  preview_file_id?: Maybe<Scalars['ID']['output']>;
-  preview_file_url?: Maybe<Scalars['ID']['output']>;
-  translated_map_id?: Maybe<Scalars['ID']['output']>;
-  translated_percent?: Maybe<Scalars['String']['output']>;
-};
-
 export type GetOrigMapListInput = {
   search?: InputMaybe<Scalars['String']['input']>;
 };
@@ -386,23 +369,6 @@ export type GetOrigMapsListOutput = {
 
 export type GetTranslatedMapContentInput = {
   translated_map_id: Scalars['ID']['input'];
-};
-
-export type GetTranslatedMapContentOutput = {
-  __typename?: 'GetTranslatedMapContentOutput';
-  content_file_id: Scalars['String']['output'];
-  content_file_url: Scalars['String']['output'];
-  created_at: Scalars['String']['output'];
-  created_by: Scalars['ID']['output'];
-  is_original: Scalars['Boolean']['output'];
-  language: LanguageOutput;
-  map_file_name: Scalars['String']['output'];
-  map_file_name_with_langs: Scalars['String']['output'];
-  original_map_id: Scalars['ID']['output'];
-  preview_file_id?: Maybe<Scalars['ID']['output']>;
-  preview_file_url?: Maybe<Scalars['ID']['output']>;
-  translated_map_id?: Maybe<Scalars['ID']['output']>;
-  translated_percent?: Maybe<Scalars['String']['output']>;
 };
 
 export type IFile = {
@@ -487,16 +453,10 @@ export type MapDeleteOutput = {
   error: ErrorType;
 };
 
-export type MapFileListConnection = {
-  __typename?: 'MapFileListConnection';
-  edges: Array<MapFileOutputEdge>;
-  pageInfo: PageInfo;
-};
-
-export type MapFileOutput = {
-  __typename?: 'MapFileOutput';
-  content_file_id?: Maybe<Scalars['ID']['output']>;
-  content_file_url?: Maybe<Scalars['ID']['output']>;
+export type MapFileInfo = {
+  __typename?: 'MapFileInfo';
+  content_file_id: Scalars['ID']['output'];
+  content_file_url: Scalars['ID']['output'];
   created_at: Scalars['String']['output'];
   created_by: Scalars['ID']['output'];
   is_original: Scalars['Boolean']['output'];
@@ -508,6 +468,18 @@ export type MapFileOutput = {
   preview_file_url?: Maybe<Scalars['ID']['output']>;
   translated_map_id?: Maybe<Scalars['ID']['output']>;
   translated_percent?: Maybe<Scalars['String']['output']>;
+};
+
+export type MapFileListConnection = {
+  __typename?: 'MapFileListConnection';
+  edges: Array<MapFileOutputEdge>;
+  pageInfo: PageInfo;
+};
+
+export type MapFileOutput = {
+  __typename?: 'MapFileOutput';
+  error: ErrorType;
+  mapFileInfo?: Maybe<MapFileInfo>;
 };
 
 export type MapFileOutputEdge = {
@@ -1311,7 +1283,7 @@ export type Query = {
   getAllTranslationFromSiteTextDefinitionID: SiteTextTranslationWithVoteListOutput;
   getDocument: GetDocumentOutput;
   getFlagsFromRef: FlagsOutput;
-  getOrigMapContent: GetOrigMapContentOutput;
+  getOrigMapContent: MapFileOutput;
   getOrigMapPhrases: GetOrigMapPhrasesOutput;
   getOrigMapWords: GetOrigMapWordsOutput;
   getOrigMapsList: GetOrigMapsListOutput;
@@ -1329,7 +1301,7 @@ export type Query = {
   getRecommendedTranslationFromDefinitionID: TranslationWithVoteOutput;
   getRecommendedTranslationFromSiteTextDefinitionID: SiteTextTranslationWithVoteOutput;
   getSiteTextTranslationVoteStatus: SiteTextTranslationVoteStatusOutputRow;
-  getTranslatedMapContent: GetTranslatedMapContentOutput;
+  getTranslatedMapContent: MapFileOutput;
   getTranslationsByFromDefinitionId: TranslationWithVoteListOutput;
   getWordDefinitionVoteStatus: DefinitionVoteStatusOutputRow;
   getWordDefinitionsByFlag: WordDefinitionListConnection;
@@ -2699,9 +2671,9 @@ export type MapPhraseWithVotesFragmentFragment = { __typename?: 'MapPhraseWithVo
 
 export type WordWithVotesFragmentFragment = { __typename?: 'MapWordWithVotes', word: string, word_id: string, language_code: string, dialect_code?: string | null, geo_code?: string | null, definition?: string | null, definition_id?: string | null, up_votes: string, down_votes: string, translation_id: string };
 
-export type MapFileOutputFragmentFragment = { __typename?: 'MapFileOutput', is_original: boolean, original_map_id: string, translated_map_id?: string | null, map_file_name: string, translated_percent?: string | null, created_at: string, created_by: string, map_file_name_with_langs: string, preview_file_url?: string | null, language: { __typename?: 'LanguageOutput', language_code: string, dialect_code?: string | null, geo_code?: string | null } };
+export type MapFileOutputFragmentFragment = { __typename?: 'MapFileOutput', error: ErrorType, mapFileInfo?: { __typename?: 'MapFileInfo', is_original: boolean, original_map_id: string, translated_map_id?: string | null, map_file_name: string, translated_percent?: string | null, created_at: string, created_by: string, map_file_name_with_langs: string, preview_file_url?: string | null, content_file_url: string, content_file_id: string, language: { __typename?: 'LanguageOutput', language_code: string, dialect_code?: string | null, geo_code?: string | null } } | null };
 
-export type MapFileOutputEdgeFragmentFragment = { __typename?: 'MapFileOutputEdge', cursor: string, node: { __typename?: 'MapFileOutput', is_original: boolean, original_map_id: string, translated_map_id?: string | null, map_file_name: string, translated_percent?: string | null, created_at: string, created_by: string, map_file_name_with_langs: string, preview_file_url?: string | null, language: { __typename?: 'LanguageOutput', language_code: string, dialect_code?: string | null, geo_code?: string | null } } };
+export type MapFileOutputEdgeFragmentFragment = { __typename?: 'MapFileOutputEdge', cursor: string, node: { __typename?: 'MapFileOutput', error: ErrorType, mapFileInfo?: { __typename?: 'MapFileInfo', is_original: boolean, original_map_id: string, translated_map_id?: string | null, map_file_name: string, translated_percent?: string | null, created_at: string, created_by: string, map_file_name_with_langs: string, preview_file_url?: string | null, content_file_url: string, content_file_id: string, language: { __typename?: 'LanguageOutput', language_code: string, dialect_code?: string | null, geo_code?: string | null } } | null } };
 
 export type GetOrigMapWordsQueryVariables = Exact<{
   original_map_id?: InputMaybe<Scalars['ID']['input']>;
@@ -2732,14 +2704,14 @@ export type GetAllMapsListQueryVariables = Exact<{
 }>;
 
 
-export type GetAllMapsListQuery = { __typename?: 'Query', getAllMapsList: { __typename?: 'MapFileListConnection', edges: Array<{ __typename?: 'MapFileOutputEdge', cursor: string, node: { __typename?: 'MapFileOutput', is_original: boolean, original_map_id: string, translated_map_id?: string | null, map_file_name: string, translated_percent?: string | null, created_at: string, created_by: string, map_file_name_with_langs: string, preview_file_url?: string | null, language: { __typename?: 'LanguageOutput', language_code: string, dialect_code?: string | null, geo_code?: string | null } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
+export type GetAllMapsListQuery = { __typename?: 'Query', getAllMapsList: { __typename?: 'MapFileListConnection', edges: Array<{ __typename?: 'MapFileOutputEdge', cursor: string, node: { __typename?: 'MapFileOutput', error: ErrorType, mapFileInfo?: { __typename?: 'MapFileInfo', is_original: boolean, original_map_id: string, translated_map_id?: string | null, map_file_name: string, translated_percent?: string | null, created_at: string, created_by: string, map_file_name_with_langs: string, preview_file_url?: string | null, content_file_url: string, content_file_id: string, language: { __typename?: 'LanguageOutput', language_code: string, dialect_code?: string | null, geo_code?: string | null } } | null } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
 export type GetTranslatedMapContentQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetTranslatedMapContentQuery = { __typename?: 'Query', getTranslatedMapContent: { __typename?: 'GetTranslatedMapContentOutput', translated_map_id?: string | null, map_file_name: string, translated_percent?: string | null, created_at: string, created_by: string, content_file_url: string, map_file_name_with_langs: string, language: { __typename?: 'LanguageOutput', language_code: string, dialect_code?: string | null, geo_code?: string | null } } };
+export type GetTranslatedMapContentQuery = { __typename?: 'Query', getTranslatedMapContent: { __typename?: 'MapFileOutput', error: ErrorType, mapFileInfo?: { __typename?: 'MapFileInfo', is_original: boolean, original_map_id: string, translated_map_id?: string | null, map_file_name: string, translated_percent?: string | null, created_at: string, created_by: string, map_file_name_with_langs: string, preview_file_url?: string | null, content_file_url: string, content_file_id: string, language: { __typename?: 'LanguageOutput', language_code: string, dialect_code?: string | null, geo_code?: string | null } } | null } };
 
 export type IsAdminLoggedInQueryVariables = Exact<{
   input: IsAdminIdInput;
@@ -2753,7 +2725,7 @@ export type GetOrigMapContentQueryVariables = Exact<{
 }>;
 
 
-export type GetOrigMapContentQuery = { __typename?: 'Query', getOrigMapContent: { __typename?: 'GetOrigMapContentOutput', original_map_id: string, map_file_name_with_langs: string, map_file_name: string, created_at: string, created_by: string, content_file_url: string } };
+export type GetOrigMapContentQuery = { __typename?: 'Query', getOrigMapContent: { __typename?: 'MapFileOutput', error: ErrorType, mapFileInfo?: { __typename?: 'MapFileInfo', is_original: boolean, original_map_id: string, translated_map_id?: string | null, map_file_name: string, translated_percent?: string | null, created_at: string, created_by: string, map_file_name_with_langs: string, preview_file_url?: string | null, content_file_url: string, content_file_id: string, language: { __typename?: 'LanguageOutput', language_code: string, dialect_code?: string | null, geo_code?: string | null } } | null } };
 
 export type MapUploadMutationVariables = Exact<{
   file: Scalars['Upload']['input'];
@@ -2763,7 +2735,7 @@ export type MapUploadMutationVariables = Exact<{
 }>;
 
 
-export type MapUploadMutation = { __typename?: 'Mutation', mapUpload: { __typename?: 'MapUploadOutput', error: ErrorType, mapFileOutput?: { __typename?: 'MapFileOutput', original_map_id: string, map_file_name: string } | null } };
+export type MapUploadMutation = { __typename?: 'Mutation', mapUpload: { __typename?: 'MapUploadOutput', error: ErrorType, mapFileOutput?: { __typename?: 'MapFileOutput', error: ErrorType, mapFileInfo?: { __typename?: 'MapFileInfo', is_original: boolean, original_map_id: string, translated_map_id?: string | null, map_file_name: string, translated_percent?: string | null, created_at: string, created_by: string, map_file_name_with_langs: string, preview_file_url?: string | null, content_file_url: string, content_file_id: string, language: { __typename?: 'LanguageOutput', language_code: string, dialect_code?: string | null, geo_code?: string | null } } | null } | null } };
 
 export type MapDeleteMutationVariables = Exact<{
   mapId: Scalars['String']['input'];
@@ -3402,20 +3374,25 @@ export const WordWithVotesFragmentFragmentDoc = gql`
     `;
 export const MapFileOutputFragmentFragmentDoc = gql`
     fragment MapFileOutputFragment on MapFileOutput {
-  is_original
-  original_map_id
-  translated_map_id
-  map_file_name
-  translated_percent
-  language {
-    language_code
-    dialect_code
-    geo_code
+  error
+  mapFileInfo {
+    is_original
+    original_map_id
+    translated_map_id
+    map_file_name
+    translated_percent
+    language {
+      language_code
+      dialect_code
+      geo_code
+    }
+    created_at
+    created_by
+    map_file_name_with_langs
+    preview_file_url
+    content_file_url
+    content_file_id
   }
-  created_at
-  created_by
-  map_file_name_with_langs
-  preview_file_url
 }
     `;
 export const MapFileOutputEdgeFragmentFragmentDoc = gql`
@@ -5364,21 +5341,10 @@ export type GetAllMapsListQueryResult = Apollo.QueryResult<GetAllMapsListQuery, 
 export const GetTranslatedMapContentDocument = gql`
     query GetTranslatedMapContent($id: ID!) {
   getTranslatedMapContent(input: {translated_map_id: $id}) {
-    translated_map_id
-    map_file_name
-    translated_percent
-    language {
-      language_code
-      dialect_code
-      geo_code
-    }
-    created_at
-    created_by
-    content_file_url
-    map_file_name_with_langs
+    ...MapFileOutputFragment
   }
 }
-    `;
+    ${MapFileOutputFragmentFragmentDoc}`;
 
 /**
  * __useGetTranslatedMapContentQuery__
@@ -5445,15 +5411,10 @@ export type IsAdminLoggedInQueryResult = Apollo.QueryResult<IsAdminLoggedInQuery
 export const GetOrigMapContentDocument = gql`
     query GetOrigMapContent($id: ID!) {
   getOrigMapContent(input: {original_map_id: $id}) {
-    original_map_id
-    map_file_name_with_langs
-    map_file_name
-    created_at
-    created_by
-    content_file_url
+    ...MapFileOutputFragment
   }
 }
-    `;
+    ${MapFileOutputFragmentFragmentDoc}`;
 
 /**
  * __useGetOrigMapContentQuery__
@@ -5492,12 +5453,11 @@ export const MapUploadDocument = gql`
   ) {
     error
     mapFileOutput {
-      original_map_id
-      map_file_name
+      ...MapFileOutputFragment
     }
   }
 }
-    `;
+    ${MapFileOutputFragmentFragmentDoc}`;
 export type MapUploadMutationFn = Apollo.MutationFunction<MapUploadMutation, MapUploadMutationVariables>;
 
 /**


### PR DESCRIPTION
- refactor types to send error to FE, also some naming changes due to refactoring of the way map date is stored (db to s3)
- remove transactions on map save (yet i think that transactions didn't block anything due to default transaction isolation level `Read committed` which shoudn't block read operations)