### PR TITLE
fix: set map list fetch policy to no cahce

### DIFF
--- a/frontend/src/components/map/MapList/MapsList.tsx
+++ b/frontend/src/components/map/MapList/MapsList.tsx
@@ -84,7 +84,7 @@ export const MapList: React.FC<MapListProps> = ({ match }: MapListProps) => {
   ] = useMapsTranslationsResetMutation();
 
   const [getAllMapsList, { data: allMapsQuery, fetchMore }] =
-    useGetAllMapsListLazyQuery();
+    useGetAllMapsListLazyQuery({ fetchPolicy: 'no-cache' });
 
   const { makeMapThumbnail } = useMapTranslationTools();
   const [isMapDeleteModalOpen, setIsMapDeleteModalOpen] = useState(false);

--- a/frontend/src/components/map/MapWordsTranslation/MapWordsList.tsx
+++ b/frontend/src/components/map/MapWordsTranslation/MapWordsList.tsx
@@ -46,6 +46,7 @@ export const MapWordsList: React.FC<MapWordsTranslationProps> = () => {
         },
         first: PAGE_SIZE,
       },
+      fetchPolicy: 'no-cache',
     });
   }, [getWordAndPhrases, targetLang]);
 


### PR DESCRIPTION
There's no easy way to manage cache updates when some translated maps were created automacically by system when a new word translation to some new language was added. Also witching to 'no-cache fetch policy' on maps list feels okay in a local environment with ~10 maps in the list. 
The same with map words/phrases list for transation (when new map was added, system automatically adds new words/phrases which was found upon parsing the map).