### PR TITLE
Bugfix: Return value 0 and invalid input errortype when parent_id is empty string

### DIFF
--- a/api/src/components/post/post.service.ts
+++ b/api/src/components/post/post.service.ts
@@ -205,6 +205,12 @@ export class PostService {
     input: PostsByParentInput,
     req: any,
   ): Promise<PostCountOutput> {
+    if (input.parent_id === '') {
+      return {
+        error: ErrorType.InvalidInputs,
+        total: 0,
+      };
+    }
     try {
       const res = await this.pg.pool.query(
         `


### PR DESCRIPTION
Closes #332 