### PR TITLE
Persist apollo caching in window

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/styled-components": "^5.1.26",
         "apollo-upload-client": "^17.0.0",
+        "apollo3-cache-persist": "^0.14.1",
         "ionicons": "^7.0.0",
         "language-tags": "^1.0.8",
         "nanoid": "^5.0.2",
@@ -503,9 +504,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.1.tgz",
-      "integrity": "sha512-kX4oXixDxG197yhX+J3Wp+NpL2wuCFjWQAr6yX2jtCnflK9ulMI51ULFGIrWiX1jGfvAxdHp+XQCcP2bZGPs9A==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.3.tgz",
+      "integrity": "sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug==",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -514,7 +515,7 @@
         "resolve": "^1.14.2"
       },
       "peerDependencies": {
-        "@babel/core": "^7.4.0-0"
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -560,11 +561,11 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -682,17 +683,17 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2223,12 +2224,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-      "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -4594,9 +4595,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -4606,12 +4607,12 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
-      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -6643,6 +6644,14 @@
         "graphql": "14 - 16"
       }
     },
+    "node_modules/apollo3-cache-persist": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/apollo3-cache-persist/-/apollo3-cache-persist-0.14.1.tgz",
+      "integrity": "sha512-p/jNzN/MmSd0TmY7/ts0B3qi0SdQ3w9yNLQdKqB3GGb9xATUlAum2v4hSrTeWd/DZKK2Z7Xg5kFXTH6nNVnKSQ==",
+      "peerDependencies": {
+        "@apollo/client": "^3.2.5"
+      }
+    },
     "node_modules/arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
@@ -6914,39 +6923,47 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.4.tgz",
-      "integrity": "sha512-9WeK9snM1BfxB38goUEv2FLnA6ja07UMfazFHzCXUb3NyDZAwfXvQiURQ6guTTMeHcOsdknULm1PDhs4uWtKyA==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.6.tgz",
+      "integrity": "sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==",
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.4.1",
-        "@nicolo-ribaudo/semver-v6": "^6.3.3"
+        "@babel/helper-define-polyfill-provider": "^0.4.3",
+        "semver": "^6.3.1"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.2.tgz",
-      "integrity": "sha512-Cid+Jv1BrY9ReW9lIfNlNpsI53N+FN7gE+f73zLAUbr9C52W4gKLWSByx47pfDJsEysojKArqOtOKZSVIIUTuQ==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.6.tgz",
+      "integrity": "sha512-leDIc4l4tUgU7str5BWLS2h8q2N4Nf6lGZP6UrNDxdtfF2g69eJ5L0H7S8A5Ln/arfFAfHor5InAdZuIOwZdgQ==",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.4.1",
-        "core-js-compat": "^3.31.0"
+        "@babel/helper-define-polyfill-provider": "^0.4.3",
+        "core-js-compat": "^3.33.1"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.1.tgz",
-      "integrity": "sha512-L8OyySuI6OSQ5hFy9O+7zFjyr4WhAfRjLIOkhQGYl+emwJkd/S4XXT1JpfrgR1jrQ1NcGiOh+yAdGlF8pnC3Jw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.3.tgz",
+      "integrity": "sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw==",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.4.1"
+        "@babel/helper-define-polyfill-provider": "^0.4.3"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/babel-plugin-syntax-trailing-function-commas": {
@@ -7102,9 +7119,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7120,10 +7137,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7274,9 +7291,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001513",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001513.tgz",
-      "integrity": "sha512-pnjGJo7SOOjAGytZZ203Em95MRM8Cr6jhCXNF/FAXTpCTRTECnqQWLpiTRqrFtdYcth8hf4WECUpkezuYsMVww==",
+      "version": "1.0.30001553",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001553.tgz",
+      "integrity": "sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A==",
       "funding": [
         {
           "type": "opencollective",
@@ -7668,11 +7685,11 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.31.1.tgz",
-      "integrity": "sha512-wIDWd2s5/5aJSdpOJHfSibxNODxoGoWOBHt8JSPB41NOE94M7kuTPZCYLOlTtuoXTsBPKobpJ6T+y0SSy5L9SA==",
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.1.tgz",
+      "integrity": "sha512-6pYKNOgD/j/bkC5xS5IIg6bncid3rfrI42oBH1SQJbsmYPKF7rhzcFzYCcxYMmNQQ0rCEB8WqpW7QHndOggaeQ==",
       "dependencies": {
-        "browserslist": "^4.21.9"
+        "browserslist": "^4.22.1"
       },
       "funding": {
         "type": "opencollective",
@@ -8317,9 +8334,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.454",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.454.tgz",
-      "integrity": "sha512-pmf1rbAStw8UEQ0sr2cdJtWl48ZMuPD9Sto8HVQOq9vx9j2WgDEN6lYoaqFvqEHYOmGA9oRGn7LqWI9ta0YugQ=="
+      "version": "1.4.564",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.564.tgz",
+      "integrity": "sha512-bGAx9+teIzL5I4esQwCMtiXtb78Ysc8xOKTPOvmafbJZ4SQ40kDO1ym3yRcGSkfaBtV81fGgHOgPoe6DsmpmkA=="
     },
     "node_modules/elementtree": {
       "version": "0.1.7",
@@ -10591,9 +10608,9 @@
       "dev": true
     },
     "node_modules/jest-get-type": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
-      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -10647,18 +10664,18 @@
       "dev": true
     },
     "node_modules/jest-message-util": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.1.tgz",
-      "integrity": "sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -10679,12 +10696,12 @@
       }
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -10699,12 +10716,12 @@
       "dev": true
     },
     "node_modules/jest-util": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
-      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -14149,9 +14166,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.26",
     "apollo-upload-client": "^17.0.0",
+    "apollo3-cache-persist": "^0.14.1",
     "ionicons": "^7.0.0",
     "language-tags": "^1.0.8",
     "nanoid": "^5.0.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,8 +35,80 @@ import { AppContextProvider } from './AppContext';
 import { ThemeProvider } from './theme';
 
 import Body from './Body';
+import {
+  split,
+  InMemoryCache,
+  ApolloClient,
+  ApolloProvider,
+} from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
+import { getMainDefinition } from '@apollo/client/utilities';
+import { createUploadLink } from 'apollo-upload-client';
+import { typePolicies } from './cacheTypePolicies';
+import { createClient } from 'graphql-ws';
+import { persistCache, LocalStorageWrapper } from 'apollo3-cache-persist';
 
 console.info('Runninig in environment: ' + import.meta.env.MODE);
+
+const server_url = `${import.meta.env.VITE_APP_SERVER_URL}/graphql`;
+const ws_server_url = `${import.meta.env.VITE_APP_WS_SERVER_URL}/graphql`;
+
+const httpLink = createUploadLink({
+  uri: server_url,
+  headers: {
+    'Apollo-Require-Preflight': 'true',
+  },
+});
+
+const wsLink = new GraphQLWsLink(
+  createClient({
+    url: ws_server_url,
+  }),
+);
+
+const splitLink = split(
+  ({ query }) => {
+    const definition = getMainDefinition(query);
+    return (
+      definition.kind === 'OperationDefinition' &&
+      definition.operation === 'subscription'
+    );
+  },
+  wsLink,
+  httpLink,
+);
+
+const authLink = setContext((_, { headers }) => {
+  // get the authentication token from local storage if it exists
+  const token = localStorage.getItem('token');
+  // return the headers to the context so httpLink can read them
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : '',
+    },
+  };
+});
+
+const cache = new InMemoryCache({
+  typePolicies,
+});
+
+await persistCache({
+  cache,
+  storage: new LocalStorageWrapper(window.localStorage),
+});
+
+export const apollo_client = new ApolloClient({
+  link: authLink.concat(splitLink),
+  cache: cache,
+});
+
+// const client = new ApolloClient({
+//   uri: 'http://localhost:3001/graphql',
+//   cache: new InMemoryCache(),
+// });
 
 setupIonicReact({
   innerHTMLTemplatesEnabled: true,
@@ -44,17 +116,19 @@ setupIonicReact({
 
 const App: React.FC = () => (
   <IonApp>
-    <AppContextProvider>
-      <ThemeProvider autoDetectPrefersDarkMode={false}>
-        <IonReactRouter>
-          <IonRouterOutlet>
-            <Route path="/">
-              <Body />
-            </Route>
-          </IonRouterOutlet>
-        </IonReactRouter>
-      </ThemeProvider>
-    </AppContextProvider>
+    <ApolloProvider client={apollo_client}>
+      <AppContextProvider>
+        <ThemeProvider autoDetectPrefersDarkMode={false}>
+          <IonReactRouter>
+            <IonRouterOutlet>
+              <Route path="/">
+                <Body />
+              </Route>
+            </IonRouterOutlet>
+          </IonReactRouter>
+        </ThemeProvider>
+      </AppContextProvider>
+    </ApolloProvider>
   </IonApp>
 );
 

--- a/frontend/src/Body.tsx
+++ b/frontend/src/Body.tsx
@@ -33,8 +33,6 @@ import {
 import { globals } from './services/globals';
 import { login_change } from './services/subscriptions';
 
-import { apollo_client } from './App';
-
 import {
   langInfo2String,
   subTags2LangInfo,
@@ -88,6 +86,7 @@ import { Header } from './components/common/Header';
 
 import { useColorModeContext } from './theme';
 import { useTr } from './hooks/useTr';
+import { ApolloClient, ApolloConsumer } from '@apollo/client';
 
 interface ToggleChangeEventDetail<T = unknown> {
   value: T;
@@ -209,7 +208,7 @@ const Body: React.FC = () => {
     router.push(`/US/${appLanguage.lang.tag}/1/login`);
   };
 
-  const click_logout = async () => {
+  const click_logout = async (apollo_client: ApolloClient<object>) => {
     toggleMenu();
 
     const token = globals.get_token();
@@ -230,8 +229,10 @@ const Body: React.FC = () => {
     globals.clear();
     login_change.next(false);
 
-    await apollo_client.clearStore();
-    await apollo_client.resetStore();
+    if (apollo_client.cache) {
+      await apollo_client.clearStore();
+      await apollo_client.resetStore();
+    }
 
     router.push(`/US/${appLanguage.lang.tag}/1/home`);
   };
@@ -322,222 +323,242 @@ const Body: React.FC = () => {
   };
 
   return (
-    <>
-      <IonMenu contentId="crowd-rock-app" ref={menuRef}>
-        <IonHeader>
-          <Header
-            onClickAppName={() => {
-              menuRef.current?.toggle();
-              goHome();
-            }}
-            onClickMenu={toggleMenu}
-            onClickDiscussion={() => {}}
-            onClickNotification={click_notifications}
-            notificationCount={unreadNotificationCount || 0}
-            isMenuHeader={true}
-          />
-        </IonHeader>
+    <ApolloConsumer>
+      {(client) => (
+        <>
+          <IonMenu contentId="crowd-rock-app" ref={menuRef}>
+            <IonHeader>
+              <Header
+                onClickAppName={() => {
+                  menuRef.current?.toggle();
+                  goHome();
+                }}
+                onClickMenu={toggleMenu}
+                onClickDiscussion={() => {}}
+                onClickNotification={click_notifications}
+                notificationCount={unreadNotificationCount || 0}
+                isMenuHeader={true}
+              />
+            </IonHeader>
 
-        <IonContent className="ion-padding">
-          <IonList>
-            <IonItem style={{ cursor: 'pointer' }}>
-              <IonToggle checked={show_dark_mode} onIonChange={toggle_theme}>
-                Turn on dark mode
-              </IonToggle>
-            </IonItem>
-            <IonItem
-              onClick={handleOpenLangSelector}
-              style={{ cursor: 'pointer' }}
-            >
-              <IonIcon aria-hidden="true" icon={languageOutline} slot="end" />
-              <IonLabel>Change App Language</IonLabel>
-            </IonItem>
-            <IonItem onClick={click_settings} style={{ cursor: 'pointer' }}>
-              <IonLabel>Settings</IonLabel>
-            </IonItem>
-
-            {is_logged_in && (
-              <>
-                <IonItem onClick={click_profile} style={{ cursor: 'pointer' }}>
-                  <IonLabel>{globals.get_avatar()}</IonLabel>
+            <IonContent className="ion-padding">
+              <IonList>
+                <IonItem style={{ cursor: 'pointer' }}>
+                  <IonToggle
+                    checked={show_dark_mode}
+                    onIonChange={toggle_theme}
+                  >
+                    Turn on dark mode
+                  </IonToggle>
                 </IonItem>
                 <IonItem
-                  onClick={click_logout}
-                  id="app-logout-button"
+                  onClick={handleOpenLangSelector}
                   style={{ cursor: 'pointer' }}
                 >
-                  <IonLabel>Logout</IonLabel>
+                  <IonIcon
+                    aria-hidden="true"
+                    icon={languageOutline}
+                    slot="end"
+                  />
+                  <IonLabel>Change App Language</IonLabel>
                 </IonItem>
-              </>
-            )}
+                <IonItem onClick={click_settings} style={{ cursor: 'pointer' }}>
+                  <IonLabel>Settings</IonLabel>
+                </IonItem>
 
-            {!is_logged_in && (
-              <>
-                <IonItem onClick={click_register} style={{ cursor: 'pointer' }}>
-                  <IonLabel>Register</IonLabel>
-                </IonItem>
-                <IonItem onClick={click_login} style={{ cursor: 'pointer' }}>
-                  <IonLabel>Login</IonLabel>
-                </IonItem>
-              </>
-            )}
-          </IonList>
-        </IonContent>
-      </IonMenu>
-      <IonPage id="crowd-rock-app">
-        <IonHeader>
-          <Header
-            onClickAppName={goHome}
-            onClickMenu={toggleMenu}
-            onClickDiscussion={() => {}}
-            onClickNotification={click_notifications}
-            notificationCount={unreadNotificationCount || 0}
-          />
-        </IonHeader>
+                {is_logged_in && (
+                  <>
+                    <IonItem
+                      onClick={click_profile}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      <IonLabel>{globals.get_avatar()}</IonLabel>
+                    </IonItem>
+                    <IonItem
+                      onClick={() => click_logout(client)}
+                      id="app-logout-button"
+                      style={{ cursor: 'pointer' }}
+                    >
+                      <IonLabel>Logout</IonLabel>
+                    </IonItem>
+                  </>
+                )}
 
-        <IonContent>
-          <IonRouterOutlet>
-            <Route
-              path="/:nation_id/:language_id/:cluster_id/profile"
-              component={Profile}
-            />
-            <Route
-              path="/:nation_id/:language_id/:cluster_id/register"
-              component={Register}
-            />
-            <Route
-              path="/:nation_id/:language_id/:cluster_id/login"
-              component={Login}
-            />
-            <Route
-              path="/:nation_id/:language_id/:cluster_id/home"
-              component={Home}
-            />
-            <Route
-              path="/:nation_id/:language_id/:cluster_id/email/:token"
-              component={EmailResponsePage}
-            />
-            <Route
-              path="/:nation_id/:language_id/:cluster_id/reset-email-request"
-              component={ResetEmailRequestPage}
-            />
-            <Route
-              path="/:nation_id/:language_id/:cluster_id/password-reset-form/:token"
-              component={PasswordResetFormPage}
-            />
-            <Route
-              path="/:nation_id/:language_id/:cluster_id/maps"
-              component={MapsPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/site-text-list"
-              component={SiteTextListPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/site-text-detail/:definition_type/:site_text_id"
-              component={SiteTextDetailPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/dictionary-list"
-              component={WordListPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/discussion/:parent/:parent_id"
-              component={DiscussionPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/dictionary-detail/:word_id"
-              component={WordDetailPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/phrase-book-list"
-              component={PhraseListPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/phrase-book-detail/:phrase_id"
-              component={PhraseDetailPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/translation"
-              component={TranslationPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/fast-translation"
-              component={FastTranslationPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/forums"
-              component={ForumListPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/forums/:forum_id/:forum_name"
-              component={ForumDetailPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/notifications"
-              component={NotificationPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/ai-controller"
-              component={AIControllerPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/settings"
-              component={SettingsPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/documents"
-              component={DocumentsPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/documents/:document_id"
-              component={DocumentViewerPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/qa"
-              component={QADocumentListPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/qa/documents/:document_id"
-              component={QADocumentViewerPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/pericopies"
-              component={PericopeDocumentListPage}
-            />
-            <Route
-              exact
-              path="/:nation_id/:language_id/:cluster_id/pericopies/documents/:document_id"
-              component={PericopeDocumentViewerPage}
-            />
-            <Route exact path="/demos/icons" component={Icons} />
-            <Route exact path="/demos/forms" component={Forms} />
-            <Route exact path="/">
-              <Redirect to={`/US/${appLanguage.lang.tag}/1/home`} />
-            </Route>
-          </IonRouterOutlet>
-        </IonContent>
-      </IonPage>
-    </>
+                {!is_logged_in && (
+                  <>
+                    <IonItem
+                      onClick={click_register}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      <IonLabel>Register</IonLabel>
+                    </IonItem>
+                    <IonItem
+                      onClick={click_login}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      <IonLabel>Login</IonLabel>
+                    </IonItem>
+                  </>
+                )}
+              </IonList>
+            </IonContent>
+          </IonMenu>
+          <IonPage id="crowd-rock-app">
+            <IonHeader>
+              <Header
+                onClickAppName={goHome}
+                onClickMenu={toggleMenu}
+                onClickDiscussion={() => {}}
+                onClickNotification={click_notifications}
+                notificationCount={unreadNotificationCount || 0}
+              />
+            </IonHeader>
+
+            <IonContent>
+              <IonRouterOutlet>
+                <Route
+                  path="/:nation_id/:language_id/:cluster_id/profile"
+                  component={Profile}
+                />
+                <Route
+                  path="/:nation_id/:language_id/:cluster_id/register"
+                  component={Register}
+                />
+                <Route
+                  path="/:nation_id/:language_id/:cluster_id/login"
+                  component={Login}
+                />
+                <Route
+                  path="/:nation_id/:language_id/:cluster_id/home"
+                  component={Home}
+                />
+                <Route
+                  path="/:nation_id/:language_id/:cluster_id/email/:token"
+                  component={EmailResponsePage}
+                />
+                <Route
+                  path="/:nation_id/:language_id/:cluster_id/reset-email-request"
+                  component={ResetEmailRequestPage}
+                />
+                <Route
+                  path="/:nation_id/:language_id/:cluster_id/password-reset-form/:token"
+                  component={PasswordResetFormPage}
+                />
+                <Route
+                  path="/:nation_id/:language_id/:cluster_id/maps"
+                  component={MapsPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/site-text-list"
+                  component={SiteTextListPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/site-text-detail/:definition_type/:site_text_id"
+                  component={SiteTextDetailPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/dictionary-list"
+                  component={WordListPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/discussion/:parent/:parent_id"
+                  component={DiscussionPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/dictionary-detail/:word_id"
+                  component={WordDetailPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/phrase-book-list"
+                  component={PhraseListPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/phrase-book-detail/:phrase_id"
+                  component={PhraseDetailPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/translation"
+                  component={TranslationPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/fast-translation"
+                  component={FastTranslationPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/forums"
+                  component={ForumListPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/forums/:forum_id/:forum_name"
+                  component={ForumDetailPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/notifications"
+                  component={NotificationPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/ai-controller"
+                  component={AIControllerPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/settings"
+                  component={SettingsPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/documents"
+                  component={DocumentsPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/documents/:document_id"
+                  component={DocumentViewerPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/qa"
+                  component={QADocumentListPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/qa/documents/:document_id"
+                  component={QADocumentViewerPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/pericopies"
+                  component={PericopeDocumentListPage}
+                />
+                <Route
+                  exact
+                  path="/:nation_id/:language_id/:cluster_id/pericopies/documents/:document_id"
+                  component={PericopeDocumentViewerPage}
+                />
+                <Route exact path="/demos/icons" component={Icons} />
+                <Route exact path="/demos/forms" component={Forms} />
+                <Route exact path="/">
+                  <Redirect to={`/US/${appLanguage.lang.tag}/1/home`} />
+                </Route>
+              </IonRouterOutlet>
+            </IonContent>
+          </IonPage>
+        </>
+      )}
+    </ApolloConsumer>
   );
 };
 

--- a/frontend/src/Body.tsx
+++ b/frontend/src/Body.tsx
@@ -33,7 +33,7 @@ import {
 import { globals } from './services/globals';
 import { login_change } from './services/subscriptions';
 
-import { apollo_client } from './main';
+import { apollo_client } from './App';
 
 import {
   langInfo2String,

--- a/frontend/src/components/authentication/Login.tsx
+++ b/frontend/src/components/authentication/Login.tsx
@@ -11,7 +11,7 @@ import { useHistory } from 'react-router';
 
 import { PageLayout } from '../common/PageLayout';
 
-import { apollo_client } from '../../main';
+import { apollo_client } from '../../App';
 import {
   ErrorType,
   useLoginMutation,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -14,6 +14,7 @@ import { setContext } from '@apollo/client/link/context';
 import { createClient } from 'graphql-ws';
 
 import { typePolicies } from './cacheTypePolicies';
+import { persistCache, LocalStorageWrapper } from 'apollo3-cache-persist';
 
 const server_url = `${import.meta.env.VITE_APP_SERVER_URL}/graphql`;
 const ws_server_url = `${import.meta.env.VITE_APP_WS_SERVER_URL}/graphql`;
@@ -55,11 +56,18 @@ const authLink = setContext((_, { headers }) => {
   };
 });
 
+const cache = new InMemoryCache({
+  typePolicies,
+});
+
+await persistCache({
+  cache,
+  storage: new LocalStorageWrapper(window.localStorage),
+});
+
 export const apollo_client = new ApolloClient({
   link: authLink.concat(splitLink),
-  cache: new InMemoryCache({
-    typePolicies,
-  }),
+  cache: cache,
 });
 
 // const client = new ApolloClient({
@@ -69,6 +77,7 @@ export const apollo_client = new ApolloClient({
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
+
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apollo_client}>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,87 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-import {
-  split,
-  ApolloClient,
-  InMemoryCache,
-  ApolloProvider,
-} from '@apollo/client';
-import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
-import { getMainDefinition } from '@apollo/client/utilities';
-import { createUploadLink } from 'apollo-upload-client';
-import { setContext } from '@apollo/client/link/context';
-import { createClient } from 'graphql-ws';
-
-import { typePolicies } from './cacheTypePolicies';
-import { persistCache, LocalStorageWrapper } from 'apollo3-cache-persist';
-
-const server_url = `${import.meta.env.VITE_APP_SERVER_URL}/graphql`;
-const ws_server_url = `${import.meta.env.VITE_APP_WS_SERVER_URL}/graphql`;
-
-const httpLink = createUploadLink({
-  uri: server_url,
-  headers: {
-    'Apollo-Require-Preflight': 'true',
-  },
-});
-
-const wsLink = new GraphQLWsLink(
-  createClient({
-    url: ws_server_url,
-  }),
-);
-
-const splitLink = split(
-  ({ query }) => {
-    const definition = getMainDefinition(query);
-    return (
-      definition.kind === 'OperationDefinition' &&
-      definition.operation === 'subscription'
-    );
-  },
-  wsLink,
-  httpLink,
-);
-
-const authLink = setContext((_, { headers }) => {
-  // get the authentication token from local storage if it exists
-  const token = localStorage.getItem('token');
-  // return the headers to the context so httpLink can read them
-  return {
-    headers: {
-      ...headers,
-      authorization: token ? `Bearer ${token}` : '',
-    },
-  };
-});
-
-const cache = new InMemoryCache({
-  typePolicies,
-});
-
-await persistCache({
-  cache,
-  storage: new LocalStorageWrapper(window.localStorage),
-});
-
-export const apollo_client = new ApolloClient({
-  link: authLink.concat(splitLink),
-  cache: cache,
-});
-
-// const client = new ApolloClient({
-//   uri: 'http://localhost:3001/graphql',
-//   cache: new InMemoryCache(),
-// });
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
 
 root.render(
   <React.StrictMode>
-    <ApolloProvider client={apollo_client}>
-      <App />
-    </ApolloProvider>
+    <App />
   </React.StrictMode>,
 );


### PR DESCRIPTION
Closes #379 
This will keep the manually triggered refreshes from completely wiping out apollo caching so that when apollo refreshes its cache it won't throw a undefined error.
Set up is as suggested in apollo docs: 
https://www.apollographql.com/docs/react/caching/advanced-topics/#persisting-the-cache